### PR TITLE
Accessibility Changes Pt. 2

### DIFF
--- a/classa11y.theme
+++ b/classa11y.theme
@@ -107,6 +107,25 @@ function classa11y_preprocess_block(array &$variables) {
 }
 
 /**
+ * Implements hook_preprocess_hook() for form elements.
+ */
+function classa11y_preprocess_input(&$variables) {
+  if (array_key_exists('data-drupal-selector', $variables['attributes']) &&
+    $variables['attributes']['data-drupal-selector'] == 'edit-managed-file-upload') {
+    $variables['attributes']['class'][] = 'js-aria-label-add';
+  }
+}
+
+/**
+ * Implements hook_preprocess_hook() for form element labels.
+ */
+function classa11y_preprocess_form_element_label(&$variables) {
+  if (isset($variables['element']['#label_type']) && $variables['element']['#label_type'] == 'managed_file') {
+    $variables['label_only'] = trim($variables['title']['#markup']);
+  }
+}
+
+/**
  * Implements hook_preprocess_hook() for html.
  */
 function classa11y_preprocess_html(array &$variables) {

--- a/css/theme.css
+++ b/css/theme.css
@@ -1,41 +1,19 @@
-.page a {
-  color: #fff;
-  background-color: #023587;
-  border-color: #023587;
+.page a,
+.page a:active {
+  border-radius: 0.25rem;
+  color: #023587;
   display: inline-block;
-  font-weight: 400;
-  text-align: center;
-  vertical-align: middle;
+  font-size: 1rem;
+  text-decoration: underline;
+  transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+
+  user-select: none;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
-  user-select: none;
-  padding: 0.375rem 0.75rem;
-  font-size: 1rem;
-  line-height: 1.5;
-  border-radius: 0.25rem;
-  transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
 }
 
-.page a:active,
 .page a:hover,
 .page a:focus {
-  outline: 0;
-}
-
-.page a:active {
-  color: #fff;
-  background-color: #022866;
-  border-color: #022866;
-}
-
-.page a:focus {
-  box-shadow: 0 0 0 0.2rem rgba(38, 143, 255, 0.5);
-}
-
-.page a:hover {
-  color: #fff;
-  background-color: #022866;
-  border-color: #022866;
   text-decoration: none;
 }

--- a/js/theme.js
+++ b/js/theme.js
@@ -1,0 +1,30 @@
+((function ($, Drupal) {
+  'use strict';
+
+  Drupal.behaviors.accessibityAdditions = {
+    attach: function (context, settings) {
+
+      // Add aria-label to managed file elements based on the span modified in theme.preprocess.
+      $('.form-type-managed-file').once('managedfiles').each(function( index ) {
+        var text = $(this).find('span').text().trim();
+        $(this).find('.js-form-managed-file .js-aria-label-add').attr('aria-label', text);
+      });
+
+      // Give selects a selected value, and update when changed.
+      $('select').once('selectinit').each(function( index ) {
+        var $selectedOptions = $(this).find("option:selected");
+        console.log($selectedOptions);
+        $selectedOptions.each(function( index ) {
+          $(this).attr("selected",true);
+        });
+      });
+
+      $(document).once('selectupdate').on("change","select",function(){
+        console.log('changed');
+        $(this).find('option[value="' + $(this).val() + '"]')
+          .attr("selected", true).siblings()
+          .removeAttr("selected")
+      });
+    }
+  };
+})(jQuery, Drupal));

--- a/templates/dataset/table.html.twig
+++ b/templates/dataset/table.html.twig
@@ -1,0 +1,119 @@
+{#
+/**
+ * @file
+ * Theme override to display a table.
+ *
+ * Available variables:
+ * - attributes: HTML attributes to apply to the <table> tag.
+ * - caption: A localized string for the <caption> tag.
+ * - colgroups: Column groups. Each group contains the following properties:
+ *   - attributes: HTML attributes to apply to the <col> tag.
+ *     Note: Drupal currently supports only one table header row, see
+ *     https://www.drupal.org/node/893530 and
+ *     http://api.drupal.org/api/drupal/includes!theme.inc/function/theme_table/7#comment-5109.
+ * - header: Table header cells. Each cell contains the following properties:
+ *   - tag: The HTML tag name to use; either 'th' or 'td'.
+ *   - attributes: HTML attributes to apply to the tag.
+ *   - content: A localized string for the title of the column.
+ *   - field: Field name (required for column sorting).
+ *   - sort: Default sort order for this column ("asc" or "desc").
+ * - sticky: A flag indicating whether to use a "sticky" table header.
+ * - rows: Table rows. Each row contains the following properties:
+ *   - attributes: HTML attributes to apply to the <tr> tag.
+ *   - data: Table cells.
+ *   - no_striping: A flag indicating that the row should receive no
+ *     'even / odd' styling. Defaults to FALSE.
+ *   - cells: Table cells of the row. Each cell contains the following keys:
+ *     - tag: The HTML tag name to use; either 'th' or 'td'.
+ *     - attributes: Any HTML attributes, such as "colspan", to apply to the
+ *       table cell.
+ *     - content: The string to display in the table cell.
+ *     - active_table_sort: A boolean indicating whether the cell is the active
+         table sort.
+ * - footer: Table footer rows, in the same format as the rows variable.
+ * - empty: The message to display in an extra row if table does not have
+ *   any rows.
+ * - no_striping: A boolean indicating that the row should receive no striping.
+ * - header_columns: The number of columns in the header.
+ *
+ * @see template_preprocess_table()
+ */
+#}
+<table{{ attributes }}>
+  {% if caption %}
+    <caption>{{ caption }}</caption>
+  {% endif %}
+
+  {% for colgroup in colgroups %}
+    {% if colgroup.cols %}
+      <colgroup{{ colgroup.attributes }}>
+        {% for col in colgroup.cols %}
+          <col{{ col.attributes }} />
+        {% endfor %}
+      </colgroup>
+    {% else %}
+      <colgroup{{ colgroup.attributes }} />
+    {% endif %}
+  {% endfor %}
+
+  {% if header %}
+    <thead>
+      <tr>
+        {% set ids = [] %}
+        {% set i = 0 %}
+        {% for cell in header %}
+          {%
+            set cell_classes = [
+              cell.active_table_sort ? 'is-active',
+            ]
+          %}
+          {% set ids = ids|merge({(i): cell.content|replace({' ': '-'})}) %}
+          <{{ cell.tag }}{{ cell.attributes.addClass(cell_classes).setAttribute('scope', 'col').setAttribute('id', cell.content|replace({' ': '-'}) ) }}>
+            {{- cell.content -}}
+          </{{ cell.tag }}>
+          {% set i = i + 1 %}
+        {% endfor %}
+      </tr>
+    </thead>
+  {% endif %}
+
+  {% if rows %}
+    <tbody>
+      {% for row in rows %}
+        {%
+          set row_classes = [
+            not no_striping ? cycle(['odd', 'even'], loop.index0),
+          ]
+        %}
+        <tr{{ row.attributes.addClass(row_classes) }}>
+          {% set i = 0 %}
+          {% for cell in row.cells %}
+            <{{ cell.tag }}{{ cell.attributes.setAttribute('scope', 'row').setAttribute('headers', ids[(i)] ) }}>
+              {{- cell.content -}}
+            </{{ cell.tag }}>
+            {% set i = i + 1 %}
+          {% endfor %}
+        </tr>
+      {% endfor %}
+    </tbody>
+  {% elseif empty %}
+    <tbody>
+      <tr class="odd">
+        <td colspan="{{ header_columns }}" class="empty message">{{ empty }}</td>
+      </tr>
+    </tbody>
+  {% endif %}
+  {% if footer %}
+    <tfoot>
+      {% for row in footer %}
+        <tr{{ row.attributes }}>
+          {% for cell in row.cells %}
+            <{{ cell.tag }}{{ cell.attributes }}>
+              {{- cell.content -}}
+            </{{ cell.tag }}>
+          {% endfor %}
+        </tr>
+      {% endfor %}
+    </tfoot>
+  {% endif %}
+</table>

--- a/templates/form/form-element-label.html.twig
+++ b/templates/form/form-element-label.html.twig
@@ -1,0 +1,29 @@
+{#
+/**
+ * @file
+ * Theme override for a form element label.
+ *
+ * Available variables:
+ * - title: The label's text.
+ * - title_display: Elements title_display setting.
+ * - required: An indicator for whether the associated form element is required.
+ * - attributes: A list of HTML attributes for the label.
+ *
+ * @see template_preprocess_form_element_label()
+ */
+#}
+{%
+  set classes = [
+    title_display == 'after' ? 'option',
+    title_display == 'invisible' ? 'visually-hidden',
+    required ? 'js-form-required',
+    required ? 'form-required',
+  ]
+%}
+{% if title is not empty or required -%}
+  {% if label_only %}
+    {{ label_only }}
+  {% else %}
+    <label{{ attributes.addClass(classes) }}>{{ title }}</label>
+  {% endif %}
+{%- endif %}

--- a/templates/form/form-element.html.twig
+++ b/templates/form/form-element.html.twig
@@ -1,0 +1,105 @@
+{#
+/**
+ * @file
+ * Theme override for a form element.
+ *
+ * Available variables:
+ * - attributes: HTML attributes for the containing element.
+ * - errors: (optional) Any errors for this form element, may not be set.
+ * - prefix: (optional) The form element prefix, may not be set.
+ * - suffix: (optional) The form element suffix, may not be set.
+ * - required: The required marker, or empty if the associated form element is
+ *   not required.
+ * - type: The type of the element.
+ * - name: The name of the element.
+ * - label: A rendered label element.
+ * - label_display: Label display setting. It can have these values:
+ *   - before: The label is output before the element. This is the default.
+ *     The label includes the #title and the required marker, if #required.
+ *   - after: The label is output after the element. For example, this is used
+ *     for radio and checkbox #type elements. If the #title is empty but the
+ *     field is #required, the label will contain only the required marker.
+ *   - invisible: Labels are critical for screen readers to enable them to
+ *     properly navigate through forms but can be visually distracting. This
+ *     property hides the label for everyone except screen readers.
+ *   - attribute: Set the title attribute on the element to create a tooltip but
+ *     output no label element. This is supported only for checkboxes and radios
+ *     in \Drupal\Core\Render\Element\CompositeFormElementTrait::preRenderCompositeFormElement().
+ *     It is used where a visual label is not needed, such as a table of
+ *     checkboxes where the row and column provide the context. The tooltip will
+ *     include the title and required marker.
+ * - description: (optional) A list of description properties containing:
+ *    - content: A description of the form element, may not be set.
+ *    - attributes: (optional) A list of HTML attributes to apply to the
+ *      description content wrapper. Will only be set when description is set.
+ * - description_display: Description display setting. It can have these values:
+ *   - before: The description is output before the element.
+ *   - after: The description is output after the element. This is the default
+ *     value.
+ *   - invisible: The description is output after the element, hidden visually
+ *     but available to screen readers.
+ * - disabled: True if the element is disabled.
+ * - title_display: Title display setting.
+ *
+ * @see template_preprocess_form_element()
+ */
+#}
+{%
+  set classes = [
+    'js-form-item',
+    'form-item',
+    'js-form-type-' ~ type|clean_class,
+    'form-type-' ~ type|clean_class,
+    'js-form-item-' ~ name|clean_class,
+    'form-item-' ~ name|clean_class,
+    title_display not in ['after', 'before'] ? 'form-no-label',
+    disabled == 'disabled' ? 'form-disabled',
+    errors ? 'form-item--error',
+  ]
+%}
+{%
+  set description_classes = [
+    'description',
+    description_display == 'invisible' ? 'visually-hidden',
+  ]
+%}
+<div{{ attributes.addClass(classes) }}>
+  {% if label_display in ['before', 'invisible'] %}
+    {% if type|clean_class is same as ('managed-file') %}
+      {% set label = label|merge({'#label_type': 'managed_file'}) %}
+      <span>{{ label }}</span>
+    {% else %}
+      {{ label }}
+    {% endif %}
+  {% endif %}
+  {% if prefix is not empty %}
+    <span class="field-prefix">{{ prefix }}</span>
+  {% endif %}
+  {% if description_display == 'before' and description.content %}
+    <div{{ description.attributes }}>
+      {{ description.content }}
+    </div>
+  {% endif %}
+  {{ children }}
+  {% if suffix is not empty %}
+    <span class="field-suffix">{{ suffix }}</span>
+  {% endif %}
+  {% if label_display == 'after' %}
+    {% if type|clean_class is same as ('managed-file') %}
+      {% set label = label|merge({'#label_type': 'managed_file'}) %}
+      <span>{{ label|raw }}</span>
+    {% else %}
+      {{ label }}
+    {% endif %}
+  {% endif %}
+  {% if errors %}
+    <div class="form-item--error-message">
+      <strong>{{ errors }}</strong>
+    </div>
+  {% endif %}
+  {% if description_display in ['after', 'invisible'] and description.content %}
+    <div{{ description.attributes.addClass(description_classes) }}>
+      {{ description.content }}
+    </div>
+  {% endif %}
+</div>


### PR DESCRIPTION
Second set of comments mentioned in https://prometprojects.atlassian.net/browse/A11Y-1, all but the first were addressed. The test image button on the style guide page doesn't have any valuable title to use for the alt text, so it was determined it is a user level requirement to add alt text to form image buttons at the time of creation.